### PR TITLE
Multi route/auth

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -72,9 +72,9 @@ jobs:
           ecr_registry_region: us-west-2
 
       - name: deploy
-        working-directory: e2e/echo
         run: |
           go run cmd/monad/main.go deploy \
+            --chdir e2e/echo \
             --env file://.env.tmpl \
             --policy file://policy.json.tmpl \
             --rule file://rule.json.tmpl \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: build
         run: |
           BRANCH=${{ env.RELEVANT_BRANCH }} \
-          docker buildx bake --push
+          docker buildx bake echo --push
 
   deployment:
     needs: integration

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: deploy
         working-directory: e2e/echo
         run: |
-          monad deploy \
+          go run cmd/monad/main.go deploy \
             --env file://.env.tmpl \
             --policy file://policy.json.tmpl \
             --rule file://rule.json.tmpl \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -81,7 +81,11 @@ jobs:
             --memory 256 \
             --disk 1024 \
             --timeout 10 \
-            --api kaixo
+            --api kaixo \
+            --route "ANY /{{.Git.Repo}}/{{.Git.Branch}}/{{.Monad.Service}}/{proxy+}" \
+            --auth aws_iam \
+            --route "ANY /{{.Git.Repo}}/{{.Git.Branch}}/{{.Monad.Service}}/public/{proxy+}" \
+            --auth none
 
   e2e:
     runs-on: ubuntu-24.04-arm
@@ -116,6 +120,10 @@ jobs:
       - name: health
         working-directory: e2e
         run: shellspec --color spec/health/sigv4_spec.sh
+      
+      - name: public health
+        working-directory: e2e
+        run: shellspec --color spec/health/none_spec.sh
 
       - name: lambda
         working-directory: e2e

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: destroy
         working-directory: e2e/echo
-        run: monad destroy --branch ${{ env.RELEVANT_BRANCH }}
+        run: go run cmd/monad/main.go destroy --branch ${{ env.RELEVANT_BRANCH }}
 
   untag:
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
 
       - name: untag
         working-directory: e2e/echo
-        run: monad ecr untag --branch ${{ env.RELEVANT_BRANCH }}
+        run: go run cmd/monad/main.go ecr untag --branch ${{ env.RELEVANT_BRANCH }}
 
 
 

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -39,8 +39,11 @@ jobs:
           ecr_registry_region: us-west-2
 
       - name: destroy
-        working-directory: e2e/echo
-        run: go run cmd/monad/main.go destroy --branch ${{ env.RELEVANT_BRANCH }}
+        run: |
+          go run cmd/monad/main.go 
+          --chdir e2e/echo \
+          --branch ${{ env.RELEVANT_BRANCH }} \
+          destroy
 
   untag:
     runs-on: ubuntu-latest
@@ -71,8 +74,11 @@ jobs:
           ecr_registry_region: us-west-2
 
       - name: untag
-        working-directory: e2e/echo
-        run: go run cmd/monad/main.go ecr untag --branch ${{ env.RELEVANT_BRANCH }}
+        run: |
+          go run cmd/monad/main.go \
+          --chdir e2e/echo \
+          --branch ${{ env.RELEVANT_BRANCH }} \
+          ecr untag
 
 
 

--- a/cmd/monad/router/route/compose.go
+++ b/cmd/monad/router/route/compose.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Compose struct {
-	param.Registry
+	param.RegistryConfig
 	Dockerfile   string `arg:"-f,--file" help:"path to dockerfile"`
 	BuildContext string `arg:"--build-context" help:"path to build context"`
 }
@@ -19,7 +19,7 @@ type Compose struct {
 func (c *Compose) Route(ctx context.Context, r Root) error {
 	var err error
 
-	if err := c.Registry.Validate(ctx, r.AwsConfig); err != nil {
+	if err := c.RegistryConfig.Validate(ctx, r.AwsConfig); err != nil {
 		return err
 	}
 
@@ -38,7 +38,7 @@ func (c *Compose) Route(ctx context.Context, r Root) error {
 	}
 
 	name := r.Service.Name
-	tag := fmt.Sprintf("%s/%s:%s", c.Registry.Client.Url, r.Service.Image, r.Git.Branch)
+	tag := fmt.Sprintf("%s/%s:%s", c.RegistryConfig.Client.Url, r.Service.Image, r.Git.Branch)
 
 	compose := &ctypes.Config{}
 

--- a/cmd/monad/router/route/deploy.go
+++ b/cmd/monad/router/route/deploy.go
@@ -19,7 +19,7 @@ func (d *Deploy) Route(ctx context.Context, r Root) error {
 
 	img := strings.Split(r.Service.Image, ":")
 
-	image, err := d.Registry.GetImage(ctx, img[0], img[1])
+	image, err := d.Registry().Client().GetImage(ctx, img[0], img[1])
 	if err != nil {
 		return err
 	}

--- a/cmd/monad/router/route/ecr.go
+++ b/cmd/monad/router/route/ecr.go
@@ -10,7 +10,7 @@ import (
 type SubCommand struct{}
 
 type Ecr struct {
-	param.Registry
+	param.RegistryConfig
 	Init   *SubCommand `arg:"subcommand:init" help:"initialize a repository"`
 	Delete *SubCommand `arg:"subcommand:delete" help:"delete a repository"`
 	Tag    *SubCommand `arg:"subcommand:tag" help:"tag an image"`
@@ -19,27 +19,27 @@ type Ecr struct {
 }
 
 func (e *Ecr) Route(ctx context.Context, r Root) error {
-	if err := e.Registry.Validate(ctx, r.AwsConfig); err != nil {
+	if err := e.RegistryConfig.Validate(ctx, r.AwsConfig); err != nil {
 		return err
 	}
 
 	switch {
 	case r.Ecr.Login != nil:
-		if err := e.Registry.Login(ctx); err != nil {
+		if err := e.RegistryConfig.Login(ctx); err != nil {
 			return err
 		}
 	case r.Ecr.Untag != nil:
-		if err := e.Registry.Untag(ctx, r.Service.ImagePath, r.Service.ImageTag); err != nil {
+		if err := e.RegistryConfig.Untag(ctx, r.Service.ImagePath, r.Service.ImageTag); err != nil {
 			return err
 		}
 	case r.Ecr.Tag != nil:
-		fmt.Printf("%s/%s", e.Registry.Client.Url, r.Service.Image)
+		fmt.Printf("%s/%s", e.RegistryConfig.Client.Url, r.Service.Image)
 	case r.Ecr.Init != nil:
-		if err := e.Registry.CreateRepository(ctx, r.Service.ImagePath); err != nil {
+		if err := e.RegistryConfig.CreateRepository(ctx, r.Service.ImagePath); err != nil {
 			return err
 		}
 	case r.Ecr.Delete != nil:
-		if err := e.Registry.DeleteRepository(ctx, r.Service.ImagePath); err != nil {
+		if err := e.RegistryConfig.DeleteRepository(ctx, r.Service.ImagePath); err != nil {
 			return err
 		}
 	}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,17 +1,30 @@
-group "default" {
-  targets = ["build"]
-}
+# group "default" {
+#   targets = ["echo"]
+# }
 
 variable "BRANCH" {
   description = "Branch name"
   required = true
 }
 
-target "build" {
-  context = "e2e/echo"
+target "monad" {
+  context = "."
+  description = "scratch image containing monad binary"
   platforms = ["linux/amd64", "linux/arm64"]
+  load = true
 
   output = [
-    "type=image,name=677771948337.dkr.ecr.us-west-2.amazonaws.com/bkeane/monad/echo:${BRANCH},push=true"
+    "type=image,name=677771948337.dkr.ecr.us-west-2.amazonaws.com/bkeane/monad/cmd:${BRANCH}",
+  ]
+}
+
+target "echo" {
+  context = "e2e/echo"
+  description = "scratch image containing e2e echo service"
+  platforms = ["linux/amd64", "linux/arm64"]
+  load = true
+
+  output = [
+    "type=image,name=677771948337.dkr.ecr.us-west-2.amazonaws.com/bkeane/monad/echo:${BRANCH}"
   ]
 }

--- a/e2e/echo/src/main.py
+++ b/e2e/echo/src/main.py
@@ -15,7 +15,8 @@ app = FastAPI(
     title="Echo",
     description="Echo is an introspection service for assisting e2e tests.",
     version="0.0.1",
-    docs_url="/",
+    docs_url="/public/docs",
+    openapi_url="/public/openapi.json",
     debug=True
 )
 
@@ -45,6 +46,10 @@ async def configure_boto3(request: Request, call_next):
 
 @app.get("/health")
 async def health():
+    return {"status": "ok"}
+
+@app.get("/public/health")
+async def public_health():
     return {"status": "ok"}
 
 @app.post("/events")

--- a/e2e/spec/health/none_spec.sh
+++ b/e2e/spec/health/none_spec.sh
@@ -1,6 +1,7 @@
 Describe "Health (no auth)"
+  target="https://${MONAD_HOST}/${MONAD_REPO}/${MONAD_BRANCH}/${MONAD_SERVICE}/public/health"
   It "${MONAD_SERVICE}"
-    When call curl_until 200 "https://${MONAD_HOST}/${MONAD_REPO}/${MONAD_BRANCH}/${MONAD_SERVICE}/health"
+    When call curl_until 200 "${target}"
     The output should include 200
     The status should be success
   End

--- a/pkg/param/apigateway.go
+++ b/pkg/param/apigateway.go
@@ -3,6 +3,7 @@ package param
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,125 +14,157 @@ import (
 
 type ApiGateway struct {
 	Client       *apigatewayv2.Client `arg:"-" json:"-"`
-	Id           string               `arg:"-" json:"-"`
 	Api          string               `arg:"--api,env:MONAD_API" placeholder:"id|name" help:"api gateway" default:"no-gateway"`
-	Route        string               `arg:"--route,env:MONAD_ROUTE" placeholder:"pattern" help:"api gateway route pattern" default:"ANY /{{.Git.Repo}}/{{.Git.Branch}}/{{.Monad.Service}}/{proxy+}"`
-	Auth         string               `arg:"--auth,env:MONAD_AUTH" placeholder:"id|name" help:"none | aws_iam | name | id" default:"aws_iam"`
 	Region       string               `arg:"--api-region,env:MONAD_API_REGION" placeholder:"name" help:"api gateway region" default:"caller-region"`
-	AuthType     string               `arg:"-" json:"-"` // `arg:"--api-auth-type" placeholder:"name" default:"AWS_IAM" help:"NONE | AWS_IAM | CUSTOM | JWT"`
-	AuthorizerId string               `arg:"-" json:"-"` // `arg:"--api-auth-id" placeholder:"id" help:"authorizer id to use" default:"no-authorizer-id"`
+	Route        []string             `arg:"--route,env:MONAD_ROUTE" placeholder:"pattern" help:"api gateway route pattern" default:"ANY /{{.Git.Repo}}/{{.Git.Branch}}/{{.Monad.Service}}/{proxy+}"`
+	Auth         []string             `arg:"--auth,env:MONAD_AUTH" placeholder:"id|name" help:"none | aws_iam | name | id" default:"aws_iam"`
+	ApiId        string               `arg:"-" json:"-"` // computed value
+	AuthType     []string             `arg:"-" json:"-"` // computed value
+	AuthorizerId []string             `arg:"-" json:"-"` // computed value
 }
 
 func (a *ApiGateway) Validate(ctx context.Context, awsconfig aws.Config) error {
 	a.Client = apigatewayv2.NewFromConfig(awsconfig)
 
+	// Set default values if not provided
 	if a.Region == "" {
 		a.Region = awsconfig.Region
 	}
 
-	if a.Api != "" && a.Auth == "" {
-		a.Auth = "aws_iam"
+	if len(a.Route) == 0 {
+		standard := "ANY /{{.Git.Repo}}/{{.Git.Branch}}/{{.Monad.Service}}/{proxy+}"
+		a.Route = append(a.Route, standard)
 	}
 
-	if a.Route == "" {
-		a.Route = "ANY /{{.Git.Repo}}/{{.Git.Branch}}/{{.Monad.Service}}/{proxy+}"
+	if len(a.Auth) == 0 {
+		standard := "aws_iam"
+		a.Auth = append(a.Auth, standard)
 	}
 
-	// pre-compute validations
+	// Simple validations ensuring presence of required fields and defaults
 	err := v.ValidateStruct(a,
-		v.Field(&a.Api, v.When(a.Auth != "", v.Required)),
+		v.Field(&a.Client, v.Required),
 		v.Field(&a.Route, v.Required),
 		v.Field(&a.Region, v.Required),
-		v.Field(&a.Client, v.Required),
+		v.Field(&a.Auth, v.Required),
 	)
 
 	if err != nil {
 		return err
 	}
 
-	// Resolve api and authorizer names/ids
+	// Resolve api and authorizer names/ids given an api name or id
 	if a.Api != "" {
-		a.Id, err = findApiId(ctx, a.Client, a.Api)
-		if err != nil {
-			return err
-		}
-
-		a.AuthorizerId, a.AuthType, err = findAuthIdAndType(ctx, a.Client, a.Id, a.Auth)
-		if err != nil {
+		if err = resolve(ctx, a); err != nil {
 			return err
 		}
 	}
 
 	return v.ValidateStruct(a,
-		v.Field(&a.Id, v.When(a.AuthType != "" || a.AuthorizerId != "", v.Required)),
-		v.Field(&a.AuthType, v.When(a.AuthType != "", v.In("NONE", "AWS_IAM", "CUSTOM", "JWT")), v.When(a.AuthorizerId != "", v.Required)),
-		v.Field(&a.AuthorizerId, v.When(a.AuthType != "" && (a.AuthType == "CUSTOM" || a.AuthType == "JWT"), v.Required)),
+		v.Field(&a.AuthType, v.Each(v.In("NONE", "AWS_IAM", "CUSTOM", "JWT"))),
+		v.Field(&a.AuthType, v.Length(len(a.AuthorizerId), len(a.AuthorizerId))),
+		v.Field(&a.AuthorizerId, v.Length(len(a.AuthType), len(a.AuthType))),
 	)
 }
 
-func findApiId(ctx context.Context, client *apigatewayv2.Client, apiIdOrName string) (string, error) {
+func resolve(ctx context.Context, param *ApiGateway) error {
+	if param == nil || param.Client == nil {
+		return fmt.Errorf("api gateway client is not initialized in param struct")
+	}
+
+	if err := resolveApi(ctx, param); err != nil {
+		return err
+	}
+
+	if err := resolveAuth(ctx, param); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resolveApi(ctx context.Context, param *ApiGateway) error {
 	var apiIds []string
 	var apiNames []string
 
-	apis, err := client.GetApis(ctx, &apigatewayv2.GetApisInput{})
+	apis, err := param.Client.GetApis(ctx, &apigatewayv2.GetApisInput{})
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	for _, api := range apis.Items {
 		apiIds = append(apiIds, *api.ApiId)
 		apiNames = append(apiNames, *api.Name)
 
-		if *api.Name == apiIdOrName || *api.ApiId == apiIdOrName {
-			return *api.ApiId, nil
+		if *api.Name == param.Api || *api.ApiId == param.Api {
+			param.ApiId = *api.ApiId
+			return nil
 		}
 	}
 
 	log.Error().
-		Str("given", apiIdOrName).
+		Str("given", param.Api).
 		Strs("valid_ids", apiIds).
 		Strs("valid_names", apiNames).
 		Msg("api not found")
 
-	return "", fmt.Errorf("api %s not found", apiIdOrName)
+	return fmt.Errorf("api %s not found", param.Api)
 }
 
-func findAuthIdAndType(ctx context.Context, client *apigatewayv2.Client, apiId string, authIdOrName string) (authId string, authType string, err error) {
-	switch strings.ToLower(authIdOrName) {
-	case "none", "aws_iam":
-		return "", strings.ToUpper(authIdOrName), nil
-	default:
-		var authorizerIds []string
-		var authorizerNames []string
+func resolveAuth(ctx context.Context, param *ApiGateway) error {
+	foundNames := []string{"none", "aws_iam"}
+	foundIds := []string{"", ""}
+	foundTypes := []string{"NONE", "AWS_IAM"}
 
-		authorizerNames = append(authorizerNames, "none", "aws_iam")
-
-		list, err := client.GetAuthorizers(ctx, &apigatewayv2.GetAuthorizersInput{
-			ApiId: aws.String(apiId),
-		})
-
-		if err != nil {
-			return "", "", err
-		}
-
-		for _, authorizer := range list.Items {
-			authorizerIds = append(authorizerIds, *authorizer.AuthorizerId)
-			authorizerNames = append(authorizerNames, *authorizer.Name)
-
-			if *authorizer.Name == authIdOrName || *authorizer.AuthorizerId == authIdOrName {
-				authId = *authorizer.AuthorizerId
-				authType = string(authorizer.AuthorizerType)
-				return authId, authType, nil
-			}
-		}
-
-		log.Error().
-			Str("api", apiId).
-			Strs("valid_ids", authorizerIds).
-			Strs("valid_names", authorizerNames).
-			Str("given", authIdOrName).
-			Msg("authorizer not found")
-
-		return "", "", fmt.Errorf("authorizer %s not found", authIdOrName)
+	if param.ApiId == "" {
+		return fmt.Errorf("api gateway ID is not yet resolved, cannot resolve authorizers")
 	}
+
+	index, err := param.Client.GetAuthorizers(ctx, &apigatewayv2.GetAuthorizersInput{
+		ApiId: aws.String(param.ApiId),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	for _, found := range index.Items {
+		foundNames = append(foundNames, strings.ToLower(*found.Name))
+		foundIds = append(foundIds, *found.AuthorizerId)
+		foundTypes = append(foundTypes, string(found.AuthorizerType))
+	}
+
+	// For development purposes, we can delete this check later, but for now we raise an error if the lengths are inconsistent
+	if len(foundIds) != len(foundNames) || len(foundIds) != len(foundTypes) {
+		return fmt.Errorf("inconsistent authorizer data: ids %d, names %d, types %d", len(foundIds), len(foundNames), len(foundTypes))
+	}
+
+	for _, given := range param.Auth {
+		// If the given auth is an ID, populate rest accordingly
+		if slices.Contains(foundIds, given) {
+			index := slices.Index(foundIds, given)
+			param.AuthorizerId = append(param.AuthorizerId, foundIds[index])
+			param.AuthType = append(param.AuthType, foundTypes[index])
+			continue
+		}
+
+		// If the given auth is a name, populate rest accordingly
+		if slices.Contains(foundNames, strings.ToLower(given)) {
+			index := slices.Index(foundNames, strings.ToLower(given))
+			param.AuthorizerId = append(param.AuthorizerId, foundIds[index])
+			param.AuthType = append(param.AuthType, foundTypes[index])
+			continue
+		}
+
+		// If the given auth is neither a known ID nor a name, return an error
+		log.Error().
+			Str("api", param.ApiId).
+			Strs("valid_ids", foundIds).
+			Strs("valid_names", foundNames).
+			Msg("resolve auth")
+
+		return fmt.Errorf("authorizer %s not found for api %s", given, param.ApiId)
+	}
+
+	return nil
 }

--- a/pkg/param/aws.go
+++ b/pkg/param/aws.go
@@ -6,9 +6,17 @@ import (
 	"strings"
 
 	"github.com/bkeane/monad/internal/tmpl"
+	"github.com/bkeane/monad/pkg/registry"
 	"github.com/rs/zerolog/log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	dotenvlib "github.com/joho/godotenv"
 )
 
@@ -27,49 +35,49 @@ type Aws struct {
 	Git          Git               `arg:"-" json:"-"`
 	Service      Service           `arg:"-" json:"-"`
 	TemplateData tmpl.TemplateData `arg:"-" json:"-"`
-	Caller
-	Registry
-	Lambda
-	Iam
-	Vpc
-	CloudWatch
-	ApiGateway
-	EventBridge
+	CallerConfig
+	RegistryConfig
+	LambdaConfig
+	IamConfig
+	VpcConfig
+	CloudWatchConfig
+	ApiGatewayConfig
+	EventBridgeConfig
 }
 
 func (c *Aws) Validate(ctx context.Context, awsconfig aws.Config, git Git, service Service) error {
 	c.Git = git
 	c.Service = service
 
-	if err := c.Caller.Validate(ctx, awsconfig); err != nil {
+	if err := c.CallerConfig.Validate(ctx, awsconfig); err != nil {
 		return err
 	}
 
-	if err := c.Registry.Validate(ctx, awsconfig); err != nil {
+	if err := c.RegistryConfig.Validate(ctx, awsconfig); err != nil {
 		return err
 	}
 
-	if err := c.Lambda.Validate(ctx, awsconfig); err != nil {
+	if err := c.LambdaConfig.Validate(ctx, awsconfig); err != nil {
 		return err
 	}
 
-	if err := c.Iam.Validate(ctx, awsconfig); err != nil {
+	if err := c.IamConfig.Validate(ctx, awsconfig); err != nil {
 		return err
 	}
 
-	if err := c.Vpc.Validate(ctx, awsconfig); err != nil {
+	if err := c.VpcConfig.Validate(ctx, awsconfig); err != nil {
 		return err
 	}
 
-	if err := c.CloudWatch.Validate(ctx, awsconfig); err != nil {
+	if err := c.CloudWatchConfig.Validate(ctx, awsconfig); err != nil {
 		return err
 	}
 
-	if err := c.ApiGateway.Validate(ctx, awsconfig); err != nil {
+	if err := c.ApiGatewayConfig.Validate(ctx, awsconfig); err != nil {
 		return err
 	}
 
-	if err := c.EventBridge.Validate(ctx, awsconfig); err != nil {
+	if err := c.EventBridgeConfig.Validate(ctx, awsconfig); err != nil {
 		return err
 	}
 
@@ -79,29 +87,29 @@ func (c *Aws) Validate(ctx context.Context, awsconfig aws.Config, git Git, servi
 	c.TemplateData.Git.Branch = c.Git.Branch
 	c.TemplateData.Git.Owner = c.Git.Owner
 	c.TemplateData.Git.Repo = c.Git.Repository
-	c.TemplateData.Caller.AccountId = c.Caller.AccountId
-	c.TemplateData.Caller.Region = c.Caller.Region
-	c.TemplateData.Registry.Id = c.Registry.Id
-	c.TemplateData.Registry.Region = c.Registry.Region
-	c.TemplateData.Resource.Name.Prefix = c.ResourceNamePrefix()
-	c.TemplateData.Resource.Name.Full = c.ResourceName()
-	c.TemplateData.Resource.Path.Prefix = c.ResourcePathPrefix()
-	c.TemplateData.Resource.Path.Full = c.ResourcePath()
-	c.TemplateData.Lambda.Region = c.Lambda.Region
-	c.TemplateData.Lambda.FunctionArn = c.FunctionArn()
-	c.TemplateData.Lambda.PolicyArn = c.PolicyArn()
-	c.TemplateData.Lambda.RoleArn = c.RoleArn()
-	c.TemplateData.Cloudwatch.Region = c.CloudWatch.Region
-	c.TemplateData.Cloudwatch.LogGroupArn = c.CloudwatchLogGroupArn()
-	c.TemplateData.ApiGateway.Region = c.ApiGateway.Region
-	c.TemplateData.ApiGateway.Id = c.ApiGateway.Id
-	c.TemplateData.EventBridge.Region = c.EventBridge.Region
-	c.TemplateData.EventBridge.RuleName = c.ResourceName()
-	c.TemplateData.EventBridge.BusName = c.EventBridge.BusName
+	c.TemplateData.Caller.AccountId = c.Caller().AccountId()
+	c.TemplateData.Caller.Region = c.Caller().Region()
+	c.TemplateData.Registry.Id = c.Registry().Id()
+	c.TemplateData.Registry.Region = c.Registry().Region()
+	c.TemplateData.Resource.Name.Prefix = c.Schema().NamePrefix()
+	c.TemplateData.Resource.Name.Full = c.Schema().Name()
+	c.TemplateData.Resource.Path.Prefix = c.Schema().PathPrefix()
+	c.TemplateData.Resource.Path.Full = c.Schema().Path()
+	c.TemplateData.Lambda.Region = c.Lambda().Region()
+	c.TemplateData.Lambda.FunctionArn = c.Lambda().FunctionArn()
+	c.TemplateData.Lambda.PolicyArn = c.IAM().PolicyArn()
+	c.TemplateData.Lambda.RoleArn = c.IAM().RoleArn()
+	c.TemplateData.Cloudwatch.Region = c.CloudWatch().Region()
+	c.TemplateData.Cloudwatch.LogGroupArn = c.CloudWatch().LogGroupArn()
+	c.TemplateData.ApiGateway.Region = c.ApiGateway().Region()
+	c.TemplateData.ApiGateway.Id = c.ApiGateway().ID()
+	c.TemplateData.EventBridge.Region = c.EventBridge().Region()
+	c.TemplateData.EventBridge.RuleName = c.Schema().Name()
+	c.TemplateData.EventBridge.BusName = c.EventBridge().BusName()
 
 	log.Info().
 		Str("region", awsconfig.Region).
-		Str("account", c.Caller.AccountId).
+		Str("account", c.Caller().AccountId()).
 		Msgf("aws")
 
 	return nil
@@ -109,36 +117,376 @@ func (c *Aws) Validate(ctx context.Context, awsconfig aws.Config, git Git, servi
 
 // Computed Properties
 
-func (c *Aws) ResourceNamePrefix() string {
-	return fmt.Sprintf("%s-%s", c.Git.Repository, c.Git.Branch)
+// Cross-cutting methods moved to Schema namespace:
+// c.ResourceName() -> c.Schema().Name()
+// c.ResourcePath() -> c.Schema().Path() 
+// c.Env() -> c.Schema().Environment()
+// c.Tags() -> c.Schema().Tags()
+// c.ServiceStateMetadata() -> c.Schema().StateMetadata()
+
+// Receiver Pattern Namespaces
+
+type IAMResources struct{ *Aws }
+type LambdaResources struct{ *Aws }
+type ApiGatewayResources struct{ *Aws }
+type EventBridgeResources struct{ *Aws }
+type CloudWatchResources struct{ *Aws }
+type VpcResources struct{ *Aws }
+type Schema struct{ *Aws }
+type CallerResources struct{ *Aws }
+type RegistryResources struct{ *Aws }
+
+// Resource namespace factory methods
+
+// IAM returns the IAM resource methods and configuration accessors
+func (c *Aws) IAM() IAMResources { return IAMResources{c} }
+
+// Lambda returns the Lambda resource methods and configuration accessors
+func (c *Aws) Lambda() LambdaResources { return LambdaResources{c} }
+
+// ApiGateway returns the API Gateway resource methods and configuration accessors
+func (c *Aws) ApiGateway() ApiGatewayResources { return ApiGatewayResources{c} }
+
+// EventBridge returns the EventBridge resource methods and configuration accessors
+func (c *Aws) EventBridge() EventBridgeResources { return EventBridgeResources{c} }
+
+// CloudWatch returns the CloudWatch resource methods and configuration accessors
+func (c *Aws) CloudWatch() CloudWatchResources { return CloudWatchResources{c} }
+
+// Vpc returns the VPC resource methods and configuration accessors
+func (c *Aws) Vpc() VpcResources { return VpcResources{c} }
+
+// Schema returns the cross-service resource organization and naming methods
+func (c *Aws) Schema() Schema { return Schema{c} }
+
+// Caller returns the AWS caller identity information
+func (c *Aws) Caller() CallerResources { return CallerResources{c} }
+
+// Registry returns the ECR registry configuration
+func (c *Aws) Registry() RegistryResources { return RegistryResources{c} }
+
+// IAMResources methods
+
+// RoleDocument returns the processed IAM role trust policy document from template
+func (i IAMResources) RoleDocument() (string, error) {
+	return tmpl.Template("role document", i.IamConfig.RoleTemplate, i.TemplateData)
 }
 
-func (c *Aws) ResourceName() string {
-	return fmt.Sprintf("%s-%s", c.ResourceNamePrefix(), c.Service.Name)
+// RoleArn returns the complete ARN for the IAM role
+func (i IAMResources) RoleArn() string {
+	return fmt.Sprintf("arn:aws:iam::%s:role/%s", i.Caller().AccountId(), i.Schema().Name())
 }
 
-func (c *Aws) ResourcePathPrefix() string {
-	return fmt.Sprintf("%s/%s", c.Git.Repository, c.Git.Branch)
+// PolicyDocument returns the processed IAM policy document from template
+func (i IAMResources) PolicyDocument() (string, error) {
+	return tmpl.Template("policy document", i.IamConfig.PolicyTemplate, i.TemplateData)
 }
 
-func (c *Aws) ResourcePath() string {
-	return fmt.Sprintf("%s/%s", c.ResourcePathPrefix(), c.Service.Name)
+// PolicyArn returns the complete ARN for the IAM policy
+func (i IAMResources) PolicyArn() string {
+	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", i.Caller().AccountId(), i.Schema().Name())
 }
 
-func (c *Aws) CloudwatchLogGroup() string {
-	return fmt.Sprintf("/aws/lambda/%s", c.ResourcePath())
+// BoundaryPolicy returns the boundary policy name (extracted from ARN if provided)
+func (i IAMResources) BoundaryPolicy() string {
+	if strings.HasPrefix(i.IamConfig.BoundaryPolicy, "arn:aws:iam::") {
+		return strings.Split(i.IamConfig.BoundaryPolicy, ":policy/")[1]
+	}
+	return i.IamConfig.BoundaryPolicy
 }
 
-func (c *Aws) CloudwatchLogGroupArn() string {
-	return fmt.Sprintf("arn:aws:logs:%s:%s:log-group:%s", c.CloudWatch.Region, c.Caller.AccountId, c.CloudwatchLogGroup())
+// BoundaryPolicyArn returns the complete ARN for the boundary policy
+func (i IAMResources) BoundaryPolicyArn() string {
+	if i.IamConfig.BoundaryPolicy == "" {
+		return i.IamConfig.BoundaryPolicy
+	}
+	if strings.HasPrefix(i.IamConfig.BoundaryPolicy, "arn:aws:iam::") {
+		return i.IamConfig.BoundaryPolicy
+	}
+	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", i.Caller().AccountId(), i.IamConfig.BoundaryPolicy)
 }
 
-func (c *Aws) CloudwatchLogRetention() int32 {
-	return c.CloudWatch.Retention
+// EniRoleName returns the standard AWS Lambda VPC execution role name
+func (i IAMResources) EniRoleName() string {
+	return "AWSLambdaVPCAccessExecutionRole"
 }
 
-func (c *Aws) Env() (map[string]string, error) {
-	env, err := tmpl.Template("env", c.Lambda.EnvTemplate, c.TemplateData)
+// EniRoleArn returns the complete ARN for the Lambda VPC execution role
+func (i IAMResources) EniRoleArn() string {
+	return fmt.Sprintf("arn:aws:iam::%s:role/%s", i.Caller().AccountId(), i.EniRoleName())
+}
+
+// EniRolePolicyArn returns the AWS managed policy ARN for Lambda VPC access
+func (i IAMResources) EniRolePolicyArn() string {
+	return "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+// IAM configuration accessors
+
+// Client returns the AWS IAM service client
+func (i IAMResources) Client() *iam.Client { return i.IamConfig.Client }
+
+// LambdaResources methods
+
+// FunctionArn returns the complete ARN for the Lambda function
+func (l LambdaResources) FunctionArn() string {
+	return fmt.Sprintf("arn:aws:lambda:%s:%s:function:%s",
+		l.Lambda().Region(), l.Caller().AccountId(), l.Schema().Name())
+}
+
+// Environment returns processed environment variables for the Lambda function
+func (l LambdaResources) Environment() (map[string]string, error) {
+	return l.Schema().Environment()
+}
+
+// Lambda configuration accessors
+
+// Client returns the AWS Lambda service client
+func (l LambdaResources) Client() *lambda.Client { return l.LambdaConfig.Client }
+
+// Region returns the AWS region for Lambda deployment
+func (l LambdaResources) Region() string { return l.LambdaConfig.Region }
+
+// Timeout returns the function timeout in seconds
+func (l LambdaResources) Timeout() int32 { return l.LambdaConfig.Timeout }
+
+// MemorySize returns the allocated memory in MB
+func (l LambdaResources) MemorySize() int32 { return l.LambdaConfig.MemorySize }
+
+// EphemeralStorage returns the ephemeral storage size in MB
+func (l LambdaResources) EphemeralStorage() int32 { return l.LambdaConfig.EphemeralStorage }
+
+// EnvTemplate returns the environment template string or file path
+func (l LambdaResources) EnvTemplate() string { return l.LambdaConfig.EnvTemplate }
+
+// Retries returns the number of async invoke retries
+func (l LambdaResources) Retries() int32 { return l.LambdaConfig.Retries }
+
+// ApiGatewayResources methods
+
+// RouteKeys returns all processed API Gateway route patterns
+func (a ApiGatewayResources) RouteKeys() ([]string, error) {
+	var routeKeys []string
+	for _, route := range a.ApiGatewayConfig.Route {
+		routeKey, err := tmpl.Template("route", route, a.TemplateData)
+		if err != nil {
+			return nil, err
+		}
+		routeKeys = append(routeKeys, routeKey)
+	}
+	return routeKeys, nil
+}
+
+// ForwardedPrefixes returns the path prefixes extracted from all route patterns
+// Since all routes are required to end with {proxy+}, we can simply strip that suffix
+func (a ApiGatewayResources) ForwardedPrefixes() ([]string, error) {
+	routeKeys, err := a.RouteKeys()
+	if err != nil {
+		return nil, err
+	}
+
+	var prefixes []string
+	for _, routeKey := range routeKeys {
+		path := strings.Split(routeKey, " ")[1]  // Extract path from "METHOD /path"
+		prefix := strings.TrimSuffix(path, "/{proxy+}")
+		prefixes = append(prefixes, prefix)
+	}
+	return prefixes, nil
+}
+
+// PermissionStatementId returns the Lambda permission statement ID for API Gateway
+func (a ApiGatewayResources) PermissionStatementId(apiId string) string {
+	return strings.Join([]string{"apigatewayv2", a.Schema().Name(), apiId}, "-")
+}
+
+// PermissionSourceArns returns the API Gateway execution ARNs for Lambda permissions for all routes
+func (a ApiGatewayResources) PermissionSourceArns() ([]string, error) {
+	routeKeys, err := a.RouteKeys()
+	if err != nil {
+		return nil, err
+	}
+
+	var sourceArns []string
+	for _, routeKey := range routeKeys {
+		routeWithoutVerb := strings.Split(routeKey, " ")[1]
+		permissionSourceArn := fmt.Sprintf("arn:aws:execute-api:%s:%s:%s/*/*%s",
+			a.ApiGateway().Region(), a.Caller().AccountId(), a.ApiGateway().ID(), routeWithoutVerb)
+		sourceArns = append(sourceArns, permissionSourceArn)
+	}
+	return sourceArns, nil
+}
+
+// Legacy methods for backward compatibility - use first route only
+
+// RouteKey returns the processed API Gateway route pattern for the first route (legacy method)
+func (a ApiGatewayResources) RouteKey() (string, error) {
+	routeKeys, err := a.RouteKeys()
+	if err != nil {
+		return "", err
+	}
+	if len(routeKeys) == 0 {
+		return "", fmt.Errorf("no routes configured")
+	}
+	return routeKeys[0], nil
+}
+
+// ForwardedForPrefix returns the path prefix for the first route (legacy method)
+func (a ApiGatewayResources) ForwardedForPrefix() (string, error) {
+	prefixes, err := a.ForwardedPrefixes()
+	if err != nil {
+		return "", err
+	}
+	if len(prefixes) == 0 {
+		return "", fmt.Errorf("no routes configured")
+	}
+	return prefixes[0], nil
+}
+
+// PermissionSourceArn returns the API Gateway execution ARN for the first route (legacy method)
+func (a ApiGatewayResources) PermissionSourceArn() (string, error) {
+	sourceArns, err := a.PermissionSourceArns()
+	if err != nil {
+		return "", err
+	}
+	if len(sourceArns) == 0 {
+		return "", fmt.Errorf("no routes configured")
+	}
+	return sourceArns[0], nil
+}
+
+// ApiGateway configuration accessors
+
+// Client returns the AWS API Gateway service client
+func (a ApiGatewayResources) Client() *apigatewayv2.Client { return a.ApiGatewayConfig.Client }
+
+// Region returns the AWS region for API Gateway deployment
+func (a ApiGatewayResources) Region() string { return a.ApiGatewayConfig.Region }
+
+// Api returns the API Gateway ID or name
+func (a ApiGatewayResources) Api() string { return a.ApiGatewayConfig.Api }
+
+// Route returns the list of route patterns
+func (a ApiGatewayResources) Route() []string { return a.ApiGatewayConfig.Route }
+
+// Auth returns the list of authorization configurations
+func (a ApiGatewayResources) Auth() []string { return a.ApiGatewayConfig.Auth }
+
+// ID returns the resolved API Gateway ID
+func (a ApiGatewayResources) ID() string { return a.ApiGatewayConfig.ApiId }
+
+// AuthType returns the resolved authorization types
+func (a ApiGatewayResources) AuthType() []string { return a.ApiGatewayConfig.AuthType }
+
+// AuthorizerId returns the resolved authorizer IDs
+func (a ApiGatewayResources) AuthorizerId() []string { return a.ApiGatewayConfig.AuthorizerId }
+
+// EventBridgeResources methods
+
+// RuleDocument returns the processed EventBridge rule document from template
+func (e EventBridgeResources) RuleDocument() (string, error) {
+	if e.EventBridgeConfig.RuleTemplate == "" {
+		return "", nil
+	}
+
+	content, err := tmpl.Template("rule document", e.EventBridgeConfig.RuleTemplate, e.TemplateData)
+	if err != nil {
+		return "", err
+	}
+
+	return content, nil
+}
+
+// PermissionStatementId returns the Lambda permission statement ID for EventBridge
+func (e EventBridgeResources) PermissionStatementId() string {
+	return strings.Join([]string{"eventbridge", e.EventBridgeConfig.BusName, e.Schema().Name()}, "-")
+}
+
+// EventBridge configuration accessors
+
+// Client returns the AWS EventBridge service client
+func (e EventBridgeResources) Client() *eventbridge.Client { return e.EventBridgeConfig.Client }
+
+// Region returns the AWS region for EventBridge deployment
+func (e EventBridgeResources) Region() string { return e.EventBridgeConfig.Region }
+
+// BusName returns the EventBridge custom bus name
+func (e EventBridgeResources) BusName() string { return e.EventBridgeConfig.BusName }
+
+// RuleTemplate returns the EventBridge rule template string or file path
+func (e EventBridgeResources) RuleTemplate() string { return e.EventBridgeConfig.RuleTemplate }
+
+// CloudWatchResources methods
+
+// LogGroup returns the CloudWatch log group name for the Lambda function
+func (c CloudWatchResources) LogGroup() string {
+	return fmt.Sprintf("/aws/lambda/%s", c.Schema().Path())
+}
+
+// LogGroupArn returns the complete ARN for the CloudWatch log group
+func (c CloudWatchResources) LogGroupArn() string {
+	return fmt.Sprintf("arn:aws:logs:%s:%s:log-group:%s", c.CloudWatch().Region(), c.Caller().AccountId(), c.LogGroup())
+}
+
+// LogRetention returns the log retention period in days
+func (c CloudWatchResources) LogRetention() int32 {
+	return c.CloudWatchConfig.Retention
+}
+
+// CloudWatch configuration accessors
+
+// Client returns the AWS CloudWatch service client
+func (c CloudWatchResources) Client() *cloudwatchlogs.Client { return c.CloudWatchConfig.Client }
+
+// Region returns the AWS region for CloudWatch deployment
+func (c CloudWatchResources) Region() string { return c.CloudWatchConfig.Region }
+
+// Retention returns the log retention period in days
+func (c CloudWatchResources) Retention() int32 { return c.CloudWatchConfig.Retention }
+
+// VpcResources methods
+
+// VPC configuration accessors
+
+// Client returns the AWS EC2 service client for VPC operations
+func (v VpcResources) Client() *ec2.Client { return v.VpcConfig.Client }
+
+// SecurityGroupIds returns the resolved security group IDs
+func (v VpcResources) SecurityGroupIds() []string { return v.VpcConfig.SecurityGroupIds }
+
+// SubnetIds returns the resolved subnet IDs  
+func (v VpcResources) SubnetIds() []string { return v.VpcConfig.SubnetIds }
+
+// SecurityGroups returns the security group names/IDs from configuration
+func (v VpcResources) SecurityGroups() []string { return v.VpcConfig.SecurityGroups }
+
+// Subnets returns the subnet names/IDs from configuration
+func (v VpcResources) Subnets() []string { return v.VpcConfig.Subnets }
+
+// Schema methods - cross-service resource organization and naming
+
+// NamePrefix returns the resource name prefix: {repo}-{branch}
+func (s Schema) NamePrefix() string {
+	return fmt.Sprintf("%s-%s", s.Git.Repository, s.Git.Branch)
+}
+
+// Name returns the full resource name: {repo}-{branch}-{service}
+func (s Schema) Name() string {
+	return fmt.Sprintf("%s-%s", s.NamePrefix(), s.Service.Name)
+}
+
+// PathPrefix returns the resource path prefix: {repo}/{branch}
+func (s Schema) PathPrefix() string {
+	return fmt.Sprintf("%s/%s", s.Git.Repository, s.Git.Branch)
+}
+
+// Path returns the full resource path: {repo}/{branch}/{service}
+func (s Schema) Path() string {
+	return fmt.Sprintf("%s/%s", s.PathPrefix(), s.Service.Name)
+}
+
+// Environment returns processed environment variables with cross-service metadata
+func (s Schema) Environment() (map[string]string, error) {
+	env, err := tmpl.Template("env", s.Lambda().EnvTemplate(), s.TemplateData)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +498,7 @@ func (c *Aws) Env() (map[string]string, error) {
 
 	// Inject default environment variables
 	// Generally useful and used for efficient state lookup
-	metadata := c.ServiceStateMetadata()
+	metadata := s.StateMetadata()
 	envMap["MONAD_SERVICE"] = metadata.Service
 	envMap["MONAD_OWNER"] = metadata.Owner
 	envMap["MONAD_REPO"] = metadata.Repo
@@ -158,122 +506,20 @@ func (c *Aws) Env() (map[string]string, error) {
 	envMap["MONAD_BRANCH"] = metadata.Branch
 	envMap["MONAD_IMAGE"] = metadata.Image
 
-	if c.ApiGateway.Id != "" {
-		envMap["MONAD_API"] = c.ApiGateway.Api
+	if s.ApiGateway().ID() != "" {
+		envMap["MONAD_API"] = s.ApiGateway().Api()
 	}
 
-	if c.EventBridge.RuleTemplate != "" {
-		envMap["MONAD_BUS"] = c.EventBridge.BusName
+	if s.EventBridge().RuleTemplate() != "" {
+		envMap["MONAD_BUS"] = s.EventBridge().BusName()
 	}
 
 	return envMap, nil
 }
 
-func (c *Aws) FunctionArn() string {
-	return fmt.Sprintf("arn:aws:lambda:%s:%s:function:%s",
-		c.Lambda.Region, c.Caller.AccountId, c.ResourceName())
-}
-
-func (c *Aws) RoleDocument() (string, error) {
-	return tmpl.Template("role document", c.Iam.RoleTemplate, c.TemplateData)
-}
-
-func (c *Aws) RoleArn() string {
-	return fmt.Sprintf("arn:aws:iam::%s:role/%s", c.Caller.AccountId, c.ResourceName())
-}
-
-func (c *Aws) PolicyDocument() (string, error) {
-	return tmpl.Template("policy document", c.Iam.PolicyTemplate, c.TemplateData)
-}
-
-func (c *Aws) PolicyArn() string {
-	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", c.Caller.AccountId, c.ResourceName())
-}
-
-func (c *Aws) BoundaryPolicy() string {
-	if strings.HasPrefix(c.Iam.BoundaryPolicy, "arn:aws:iam::") {
-		return strings.Split(c.Iam.BoundaryPolicy, ":policy/")[1]
-	}
-
-	return c.Iam.BoundaryPolicy
-}
-
-func (c *Aws) BoundaryPolicyArn() string {
-	if c.Iam.BoundaryPolicy == "" {
-		return c.Iam.BoundaryPolicy
-	}
-
-	if strings.HasPrefix(c.Iam.BoundaryPolicy, "arn:aws:iam::") {
-		return c.Iam.BoundaryPolicy
-	}
-
-	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", c.Caller.AccountId, c.Iam.BoundaryPolicy)
-}
-
-func (c *Aws) EniRoleName() string {
-	return "AWSLambdaVPCAccessExecutionRole"
-}
-
-func (c *Aws) EniRoleArn() string {
-	return fmt.Sprintf("arn:aws:iam::%s:role/%s", c.Caller.AccountId, c.EniRoleName())
-}
-
-func (c *Aws) EniRolePolicyArn() string {
-	return "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
-}
-
-func (c *Aws) RouteKey() (string, error) {
-	// return fmt.Sprintf("ANY /%s/{proxy+}", c.ResourcePath())
-	return tmpl.Template("route", c.ApiGateway.Route, c.TemplateData)
-}
-
-func (c *Aws) ForwardedForPrefix() (string, error) {
-	routeKey, err := c.RouteKey()
-	if err != nil {
-		return "", err
-	}
-
-	forwardedForPrefix := strings.Split(routeKey, " ")[1]
-	forwardedForPrefix = strings.Replace(forwardedForPrefix, "/{proxy+}", "", 1)
-	return forwardedForPrefix, nil
-}
-
-func (c *Aws) ApiGwPermissionStatementId(apiId string) string {
-	return strings.Join([]string{"apigatewayv2", c.ResourceName(), apiId}, "-")
-}
-
-func (c *Aws) ApiGwPermissionSourceArn() (string, error) {
-	routeKey, err := c.RouteKey()
-	if err != nil {
-		return "", err
-	}
-
-	routeWithoutVerb := strings.Split(routeKey, " ")[1]
-	permissionSourceArn := fmt.Sprintf("arn:aws:execute-api:%s:%s:%s/*/*%s",
-		c.ApiGateway.Region, c.Caller.AccountId, c.ApiGateway.Id, routeWithoutVerb)
-
-	return permissionSourceArn, nil
-}
-
-func (c *Aws) RuleDocument() (string, error) {
-	if c.EventBridge.RuleTemplate == "" {
-		return "", nil
-	}
-
-	content, err := tmpl.Template("rule document", c.EventBridge.RuleTemplate, c.TemplateData)
-	if err != nil {
-		return "", err
-	}
-
-	return content, nil
-}
-
-func (c *Aws) EventBridgeStatementId() string {
-	return strings.Join([]string{"eventbridge", c.EventBridge.BusName, c.ResourceName()}, "-")
-}
-
-func (c *Aws) Tags() map[string]string {
-	metadata := c.ServiceStateMetadata()
+// Tags returns standardized AWS resource tags for cross-service consistency
+func (s Schema) Tags() map[string]string {
+	metadata := s.StateMetadata()
 
 	return map[string]string{
 		"Monad":   "true",
@@ -285,13 +531,42 @@ func (c *Aws) Tags() map[string]string {
 	}
 }
 
-func (c *Aws) ServiceStateMetadata() *StateMetadata {
+// StateMetadata returns service metadata for state management
+func (s Schema) StateMetadata() *StateMetadata {
 	return &StateMetadata{
-		Service: c.Service.Name,
-		Owner:   c.Git.Owner,
-		Repo:    c.Git.Repository,
-		Branch:  c.Git.Branch,
-		Sha:     c.Git.Sha,
-		Image:   c.Service.Image,
+		Service: s.Service.Name,
+		Owner:   s.Git.Owner,
+		Repo:    s.Git.Repository,
+		Branch:  s.Git.Branch,
+		Sha:     s.Git.Sha,
+		Image:   s.Service.Image,
 	}
 }
+
+// CallerResources methods - AWS caller identity accessors
+
+// AccountId returns the AWS account ID
+func (c CallerResources) AccountId() string { return c.CallerConfig.AccountId }
+
+// Region returns the AWS region
+func (c CallerResources) Region() string { return c.CallerConfig.Region }
+
+// Arn returns the caller ARN
+func (c CallerResources) Arn() string { return c.CallerConfig.Arn }
+
+// UserId returns the caller user ID
+func (c CallerResources) UserId() string { return c.CallerConfig.UserId }
+
+// Client returns the AWS STS client
+func (c CallerResources) Client() *sts.Client { return c.CallerConfig.Client }
+
+// RegistryResources methods - ECR registry accessors
+
+// Id returns the ECR registry ID
+func (r RegistryResources) Id() string { return r.RegistryConfig.Id }
+
+// Region returns the ECR registry region
+func (r RegistryResources) Region() string { return r.RegistryConfig.Region }
+
+// Client returns the registry client
+func (r RegistryResources) Client() *registry.Client { return r.RegistryConfig.Client }

--- a/pkg/param/caller.go
+++ b/pkg/param/caller.go
@@ -8,7 +8,7 @@ import (
 	v "github.com/go-ozzo/ozzo-validation/v4"
 )
 
-type Caller struct {
+type CallerConfig struct {
 	Client    *sts.Client `arg:"-" json:"-"`
 	AccountId string      `arg:"-" json:"-"`
 	Region    string      `arg:"-" json:"-"`
@@ -16,7 +16,7 @@ type Caller struct {
 	UserId    string      `arg:"-" json:"-"`
 }
 
-func (c *Caller) Validate(ctx context.Context, awsconfig aws.Config) error {
+func (c *CallerConfig) Validate(ctx context.Context, awsconfig aws.Config) error {
 	c.Client = sts.NewFromConfig(awsconfig)
 
 	caller, err := c.Client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})

--- a/pkg/param/cloudwatch.go
+++ b/pkg/param/cloudwatch.go
@@ -8,13 +8,13 @@ import (
 	v "github.com/go-ozzo/ozzo-validation/v4"
 )
 
-type CloudWatch struct {
+type CloudWatchConfig struct {
 	Client    *cloudwatchlogs.Client `arg:"-" json:"-"`
 	Region    string                 `arg:"--log-region,env:MONAD_LOG_REGION" placeholder:"name" help:"cloudwatch log region"  default:"caller-region"`
 	Retention int32                  `arg:"--log-retention,env:MONAD_LOG_RETENTION" placeholder:"days" help:"1, 3, 5, 7, 14, 30..." default:"3"`
 }
 
-func (c *CloudWatch) Validate(ctx context.Context, awsconfig aws.Config) error {
+func (c *CloudWatchConfig) Validate(ctx context.Context, awsconfig aws.Config) error {
 	c.Client = cloudwatchlogs.NewFromConfig(awsconfig)
 
 	if c.Region == "" {

--- a/pkg/param/ecr.go
+++ b/pkg/param/ecr.go
@@ -18,14 +18,14 @@ import (
 	v "github.com/go-ozzo/ozzo-validation/v4"
 )
 
-type Registry struct {
+type RegistryConfig struct {
 	ecrc   *ecr.Client      `arg:"-" json:"-"`
 	Client *registry.Client `arg:"-" json:"-"`
 	Id     string           `arg:"--ecr-id,env:MONAD_REGISTRY_ID" placeholder:"id" help:"ecr registry id" default:"caller-account-id"`
 	Region string           `arg:"--ecr-region,env:MONAD_REGISTRY_REGION" placeholder:"name" help:"ecr registry region" default:"caller-region"`
 }
 
-func (r *Registry) Validate(ctx context.Context, awsconfig aws.Config) error {
+func (r *RegistryConfig) Validate(ctx context.Context, awsconfig aws.Config) error {
 	var err error
 
 	r.ecrc = ecr.NewFromConfig(awsconfig)
@@ -55,7 +55,7 @@ func (r *Registry) Validate(ctx context.Context, awsconfig aws.Config) error {
 	)
 }
 
-func (r *Registry) Login(ctx context.Context) error {
+func (r *RegistryConfig) Login(ctx context.Context) error {
 	input := &ecr.GetAuthorizationTokenInput{
 		RegistryIds: []string{r.Id},
 	}
@@ -96,7 +96,7 @@ func (r *Registry) Login(ctx context.Context) error {
 	return nil
 }
 
-func (r *Registry) Untag(ctx context.Context, repo, tag string) error {
+func (r *RegistryConfig) Untag(ctx context.Context, repo, tag string) error {
 	log.Info().
 		Str("action", "untag").
 		Str("registry", r.Id).
@@ -108,7 +108,7 @@ func (r *Registry) Untag(ctx context.Context, repo, tag string) error {
 	return r.Client.Untag(ctx, repo, tag)
 }
 
-func (r *Registry) GetImage(ctx context.Context, repo, tag string) (registry.ImagePointer, error) {
+func (r *RegistryConfig) GetImage(ctx context.Context, repo, tag string) (registry.ImagePointer, error) {
 	log.Info().
 		Str("action", "get").
 		Str("registry", r.Id).
@@ -120,7 +120,7 @@ func (r *Registry) GetImage(ctx context.Context, repo, tag string) (registry.Ima
 	return r.Client.FromPath(ctx, repo, tag)
 }
 
-func (r *Registry) CreateRepository(ctx context.Context, repo string) error {
+func (r *RegistryConfig) CreateRepository(ctx context.Context, repo string) error {
 	var apiErr smithy.APIError
 
 	log.Info().
@@ -150,7 +150,7 @@ func (r *Registry) CreateRepository(ctx context.Context, repo string) error {
 	return nil
 }
 
-func (r *Registry) DeleteRepository(ctx context.Context, repo string) error {
+func (r *RegistryConfig) DeleteRepository(ctx context.Context, repo string) error {
 	var apiErr smithy.APIError
 
 	log.Info().

--- a/pkg/param/eventbridge.go
+++ b/pkg/param/eventbridge.go
@@ -14,14 +14,14 @@ import (
 	v "github.com/go-ozzo/ozzo-validation/v4"
 )
 
-type EventBridge struct {
+type EventBridgeConfig struct {
 	Client       *eventbridge.Client `arg:"-" json:"-"`
 	BusName      string              `arg:"--bus,env:MONAD_BUS" placeholder:"name" help:"eventbridge bus name" default:"default"`
 	RuleTemplate string              `arg:"--rule,env:MONAD_RULE" placeholder:"template" help:"string | file://rule.json" default:"no-rule"`
 	Region       string              `arg:"--bus-region,env:MONAD_BUS_REGION" placeholder:"name" help:"eventbridge region" default:"caller-region"`
 }
 
-func (e *EventBridge) Validate(ctx context.Context, awsconfig aws.Config) error {
+func (e *EventBridgeConfig) Validate(ctx context.Context, awsconfig aws.Config) error {
 	e.Client = eventbridge.NewFromConfig(awsconfig)
 
 	if e.BusName == "" {

--- a/pkg/param/iam.go
+++ b/pkg/param/iam.go
@@ -11,14 +11,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 )
 
-type Iam struct {
+type IamConfig struct {
 	Client         *iam.Client `arg:"-" json:"-"`
 	PolicyTemplate string      `arg:"--policy,env:MONAD_POLICY" placeholder:"template" help:"string | file://policy.tmpl" default:"minimal-policy"`
 	RoleTemplate   string      `arg:"--role,env:MONAD_ROLE" placeholder:"template" help:"string | file://role.tmpl" default:"minimal-role"`
 	BoundaryPolicy string      `arg:"--boundary,env:MONAD_BOUNDARY_POLICY" placeholder:"arn|name" help:"boundary policy" default:"no-boundary"`
 }
 
-func (l *Iam) Validate(ctx context.Context, awsconfig aws.Config) error {
+func (l *IamConfig) Validate(ctx context.Context, awsconfig aws.Config) error {
 	var err error
 
 	l.Client = iam.NewFromConfig(awsconfig)

--- a/pkg/param/lambda.go
+++ b/pkg/param/lambda.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 )
 
-type Lambda struct {
+type LambdaConfig struct {
 	Client           *lambda.Client `arg:"-" json:"-"`
 	Region           string         `arg:"--lambda-region,env:MONAD_LAMBDA_REGION" placeholder:"name" help:"lambda region" default:"caller-region"`
 	EnvTemplate      string         `arg:"--env,env:MONAD_ENV" placeholder:"template" help:"string | file://env.tmpl" default:"minimal-env"`
@@ -21,7 +21,7 @@ type Lambda struct {
 	Retries          int32          `arg:"--retry,env:MONAD_RETRIES" placeholder:"count" help:"async function invoke retries" default:"0"`
 }
 
-func (l *Lambda) Validate(ctx context.Context, awsconfig aws.Config) error {
+func (l *LambdaConfig) Validate(ctx context.Context, awsconfig aws.Config) error {
 	var err error
 
 	l.Client = lambda.NewFromConfig(awsconfig)

--- a/pkg/param/vpc.go
+++ b/pkg/param/vpc.go
@@ -12,15 +12,15 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type Vpc struct {
+type VpcConfig struct {
 	Client           *ec2.Client `arg:"-" json:"-"`
-	SecurityGroups   []string    `arg:"--vpc-sg,env:MONAD_SECURITY_GROUPS" placeholder:"id|name" help:"vpc-default,sg-456... (comma separated) [default: []]"`
-	Subnets          []string    `arg:"--vpc-sn,env:MONAD_SUBNETS" placeholder:"id|name" help:"private,subnet-456... (comma separated) [default: []]"`
+	SecurityGroups   []string    `arg:"--vpc-sg,env:MONAD_SECURITY_GROUPS,separate" placeholder:"id|name" help:"vpc-default | sg-12345 (multiple flags supported) [default: []]"`
+	Subnets          []string    `arg:"--vpc-sn,env:MONAD_SUBNETS,separate" placeholder:"id|name" help:"private | subnet-12345 (multiple flags supported) [default: []]"`
 	SecurityGroupIds []string    `arg:"-"`
 	SubnetIds        []string    `arg:"-"`
 }
 
-func (c *Vpc) Validate(ctx context.Context, awsconfig aws.Config) error {
+func (c *VpcConfig) Validate(ctx context.Context, awsconfig aws.Config) error {
 	c.Client = ec2.NewFromConfig(awsconfig)
 
 	if err := c.ResolveSecurityGroups(ctx); err != nil {
@@ -43,7 +43,7 @@ func (c *Vpc) Validate(ctx context.Context, awsconfig aws.Config) error {
 	)
 }
 
-func (c *Vpc) ResolveSecurityGroups(ctx context.Context) error {
+func (c *VpcConfig) ResolveSecurityGroups(ctx context.Context) error {
 	for _, nameOrId := range c.SecurityGroups {
 		if strings.HasPrefix(nameOrId, "sg-") {
 			c.SecurityGroupIds = append(c.SecurityGroupIds, nameOrId)
@@ -74,7 +74,7 @@ func (c *Vpc) ResolveSecurityGroups(ctx context.Context) error {
 	return nil
 }
 
-func (c *Vpc) ResolveSubnets(ctx context.Context) error {
+func (c *VpcConfig) ResolveSubnets(ctx context.Context) error {
 	for _, nameOrId := range c.Subnets {
 		if strings.HasPrefix(nameOrId, "subnet-") {
 			c.SubnetIds = append(c.SubnetIds, nameOrId)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -209,6 +209,11 @@ func (r *Client) FromPath(ctx context.Context, path string, reference string) (I
 	return pointer, nil
 }
 
+// GetImage is an alias for FromPath to maintain consistent interface with param.Registry
+func (r *Client) GetImage(ctx context.Context, repo, tag string) (ImagePointer, error) {
+	return r.FromPath(ctx, repo, tag)
+}
+
 func (r *Client) DigImage(ctx context.Context, repository string, reference string) (string, error) {
 	resp, err := r.GetManifest(ctx, repository, reference)
 	if err != nil {

--- a/pkg/saga/cloudwatch.go
+++ b/pkg/saga/cloudwatch.go
@@ -25,15 +25,15 @@ func (s Cloudwatch) Init(ctx context.Context, c param.Aws) *Cloudwatch {
 func (s *Cloudwatch) Do(ctx context.Context) error {
 	log.Info().
 		Str("action", "put").
-		Str("group", s.config.CloudwatchLogGroup()).
-		Int32("retention", s.config.CloudwatchLogRetention()).
+		Str("group", s.config.CloudWatch().LogGroup()).
+		Int32("retention", s.config.CloudWatch().LogRetention()).
 		Msg("cloudwatch")
 
 	if err := s.PutLogGroup(ctx); err != nil {
 		return err
 	}
 
-	if err := s.PutLogGroupRetentionPolicy(ctx, s.config.CloudwatchLogRetention()); err != nil {
+	if err := s.PutLogGroupRetentionPolicy(ctx, s.config.CloudWatch().LogRetention()); err != nil {
 		return err
 	}
 
@@ -43,7 +43,7 @@ func (s *Cloudwatch) Do(ctx context.Context) error {
 func (s *Cloudwatch) Undo(ctx context.Context) error {
 	log.Info().
 		Str("action", "delete").
-		Str("group", s.config.CloudwatchLogGroup()).
+		Str("group", s.config.CloudWatch().LogGroup()).
 		Msg("cloudwatch")
 
 	if err := s.DeleteLogGroup(ctx); err != nil {
@@ -55,17 +55,17 @@ func (s *Cloudwatch) Undo(ctx context.Context) error {
 
 func (s *Cloudwatch) PutLogGroup(ctx context.Context) error {
 	var apiErr smithy.APIError
-	_, err := s.config.CloudWatch.Client.CreateLogGroup(ctx, &cloudwatchlogs.CreateLogGroupInput{
-		LogGroupName: aws.String(s.config.CloudwatchLogGroup()),
-		Tags:         s.config.Tags(),
+	_, err := s.config.CloudWatch().Client().CreateLogGroup(ctx, &cloudwatchlogs.CreateLogGroupInput{
+		LogGroupName: aws.String(s.config.CloudWatch().LogGroup()),
+		Tags:         s.config.Schema().Tags(),
 	})
 
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
 		case "ResourceAlreadyExistsException":
-			_, err := s.config.CloudWatch.Client.TagResource(ctx, &cloudwatchlogs.TagResourceInput{
-				ResourceArn: aws.String(s.config.CloudwatchLogGroupArn()),
-				Tags:        s.config.Tags(),
+			_, err := s.config.CloudWatch().Client().TagResource(ctx, &cloudwatchlogs.TagResourceInput{
+				ResourceArn: aws.String(s.config.CloudWatch().LogGroupArn()),
+				Tags:        s.config.Schema().Tags(),
 			})
 			return err
 		default:
@@ -77,8 +77,8 @@ func (s *Cloudwatch) PutLogGroup(ctx context.Context) error {
 }
 
 func (c *Cloudwatch) PutLogGroupRetentionPolicy(ctx context.Context, days int32) error {
-	_, err := c.config.CloudWatch.Client.PutRetentionPolicy(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
-		LogGroupName:    aws.String(c.config.CloudwatchLogGroup()),
+	_, err := c.config.CloudWatch().Client().PutRetentionPolicy(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
+		LogGroupName:    aws.String(c.config.CloudWatch().LogGroup()),
 		RetentionInDays: aws.Int32(days),
 	})
 
@@ -87,8 +87,8 @@ func (c *Cloudwatch) PutLogGroupRetentionPolicy(ctx context.Context, days int32)
 
 func (c *Cloudwatch) DeleteLogGroup(ctx context.Context) error {
 	var apiErr smithy.APIError
-	_, err := c.config.CloudWatch.Client.DeleteLogGroup(ctx, &cloudwatchlogs.DeleteLogGroupInput{
-		LogGroupName: aws.String(c.config.CloudwatchLogGroup()),
+	_, err := c.config.CloudWatch().Client().DeleteLogGroup(ctx, &cloudwatchlogs.DeleteLogGroupInput{
+		LogGroupName: aws.String(c.config.CloudWatch().LogGroup()),
 	})
 
 	if errors.As(err, &apiErr) {

--- a/pkg/saga/iam.go
+++ b/pkg/saga/iam.go
@@ -25,7 +25,7 @@ func (s IAM) Init(ctx context.Context, c param.Aws) *IAM {
 func (s *IAM) Do(ctx context.Context) error {
 	log.Info().
 		Str("action", "put").
-		Str("role", s.config.EniRoleName()).
+		Str("role", s.config.IAM().EniRoleName()).
 		Msg("iam")
 
 	if err := s.PutEniRole(ctx); err != nil {
@@ -34,7 +34,7 @@ func (s *IAM) Do(ctx context.Context) error {
 
 	log.Info().
 		Str("action", "put").
-		Str("policy", s.config.ResourceName()).
+		Str("policy", s.config.Schema().Name()).
 		Msg("iam")
 
 	if err := s.PutPolicy(ctx); err != nil {
@@ -43,7 +43,7 @@ func (s *IAM) Do(ctx context.Context) error {
 
 	log.Info().
 		Str("action", "put").
-		Str("role", s.config.ResourceName()).
+		Str("role", s.config.Schema().Name()).
 		Msg("iam")
 
 	if err := s.PutRole(ctx); err != nil {
@@ -52,9 +52,9 @@ func (s *IAM) Do(ctx context.Context) error {
 
 	log.Info().
 		Str("action", "attach").
-		Str("role", s.config.ResourceName()).
-		Str("policy", s.config.ResourceName()).
-		Str("boundary", s.config.BoundaryPolicy()).
+		Str("role", s.config.Schema().Name()).
+		Str("policy", s.config.Schema().Name()).
+		Str("boundary", s.config.IAM().BoundaryPolicy()).
 		Msg("iam")
 
 	if err := s.AttachRolePolicy(ctx); err != nil {
@@ -67,9 +67,9 @@ func (s *IAM) Do(ctx context.Context) error {
 func (s *IAM) Undo(ctx context.Context) error {
 	log.Info().
 		Str("action", "detach").
-		Str("role", s.config.ResourceName()).
-		Str("policy", s.config.ResourceName()).
-		Str("boundary", s.config.BoundaryPolicy()).
+		Str("role", s.config.Schema().Name()).
+		Str("policy", s.config.Schema().Name()).
+		Str("boundary", s.config.IAM().BoundaryPolicy()).
 		Msg("iam")
 
 	if err := s.DetachRolePolicy(ctx); err != nil {
@@ -78,7 +78,7 @@ func (s *IAM) Undo(ctx context.Context) error {
 
 	log.Info().
 		Str("action", "delete").
-		Str("role", s.config.ResourceName()).
+		Str("role", s.config.Schema().Name()).
 		Msg("iam")
 
 	if err := s.DeleteRole(ctx); err != nil {
@@ -87,7 +87,7 @@ func (s *IAM) Undo(ctx context.Context) error {
 
 	log.Info().
 		Str("action", "delete").
-		Str("policy", s.config.ResourceName()).
+		Str("policy", s.config.Schema().Name()).
 		Msg("iam")
 
 	if err := s.DeletePolicy(ctx); err != nil {
@@ -102,13 +102,13 @@ func (s *IAM) Undo(ctx context.Context) error {
 func (s *IAM) PutPolicy(ctx context.Context) error {
 	var apiErr smithy.APIError
 
-	policyDocument, err := s.config.PolicyDocument()
+	policyDocument, err := s.config.IAM().PolicyDocument()
 	if err != nil {
 		return err
 	}
 
 	var tagSlice []types.Tag
-	for key, value := range s.config.Tags() {
+	for key, value := range s.config.Schema().Tags() {
 		tagSlice = append(tagSlice, types.Tag{
 			Key:   aws.String(key),
 			Value: aws.String(value),
@@ -116,30 +116,30 @@ func (s *IAM) PutPolicy(ctx context.Context) error {
 	}
 
 	create := &iam.CreatePolicyInput{
-		PolicyName:     aws.String(s.config.ResourceName()),
+		PolicyName:     aws.String(s.config.Schema().Name()),
 		PolicyDocument: aws.String(policyDocument),
 	}
 
 	update := &iam.CreatePolicyVersionInput{
-		PolicyArn:      aws.String(s.config.PolicyArn()),
+		PolicyArn:      aws.String(s.config.IAM().PolicyArn()),
 		PolicyDocument: aws.String(policyDocument),
 		SetAsDefault:   true,
 	}
 
 	tag := &iam.TagPolicyInput{
-		PolicyArn: aws.String(s.config.PolicyArn()),
+		PolicyArn: aws.String(s.config.IAM().PolicyArn()),
 		Tags:      tagSlice,
 	}
 
-	_, err = s.config.Iam.Client.CreatePolicy(ctx, create)
+	_, err = s.config.IAM().Client().CreatePolicy(ctx, create)
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
 		case "EntityAlreadyExists":
-			if err := s.GCPolicyVersions(ctx, s.config.PolicyArn()); err != nil {
+			if err := s.GCPolicyVersions(ctx, s.config.IAM().PolicyArn()); err != nil {
 				return err
 			}
 
-			_, err = s.config.Iam.Client.CreatePolicyVersion(ctx, update)
+			_, err = s.config.IAM().Client().CreatePolicyVersion(ctx, update)
 			if err != nil {
 				return err
 			}
@@ -149,7 +149,7 @@ func (s *IAM) PutPolicy(ctx context.Context) error {
 		}
 	}
 
-	_, err = s.config.Iam.Client.TagPolicy(ctx, tag)
+	_, err = s.config.IAM().Client().TagPolicy(ctx, tag)
 	if err != nil {
 		return err
 	}
@@ -161,31 +161,31 @@ func (s *IAM) PutPolicy(ctx context.Context) error {
 func (s *IAM) PutEniRole(ctx context.Context) error {
 	var apiErr smithy.APIError
 
-	roleDocument, err := s.config.RoleDocument()
+	roleDocument, err := s.config.IAM().RoleDocument()
 	if err != nil {
 		return err
 	}
 
 	create := &iam.CreateRoleInput{
-		RoleName:                 aws.String(s.config.EniRoleName()),
+		RoleName:                 aws.String(s.config.IAM().EniRoleName()),
 		AssumeRolePolicyDocument: aws.String(roleDocument),
 	}
 
 	update := &iam.UpdateAssumeRolePolicyInput{
-		RoleName:       aws.String(s.config.EniRoleName()),
+		RoleName:       aws.String(s.config.IAM().EniRoleName()),
 		PolicyDocument: aws.String(roleDocument),
 	}
 
 	attach := &iam.AttachRolePolicyInput{
-		RoleName:  aws.String(s.config.EniRoleName()),
-		PolicyArn: aws.String(s.config.EniRolePolicyArn()),
+		RoleName:  aws.String(s.config.IAM().EniRoleName()),
+		PolicyArn: aws.String(s.config.IAM().EniRolePolicyArn()),
 	}
 
-	_, err = s.config.Iam.Client.CreateRole(ctx, create)
+	_, err = s.config.IAM().Client().CreateRole(ctx, create)
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
 		case "EntityAlreadyExists":
-			_, err = s.config.Iam.Client.UpdateAssumeRolePolicy(ctx, update)
+			_, err = s.config.IAM().Client().UpdateAssumeRolePolicy(ctx, update)
 			if err != nil {
 				return err
 			}
@@ -194,7 +194,7 @@ func (s *IAM) PutEniRole(ctx context.Context) error {
 		}
 	}
 
-	_, err = s.config.Iam.Client.AttachRolePolicy(ctx, attach)
+	_, err = s.config.IAM().Client().AttachRolePolicy(ctx, attach)
 	if err != nil {
 		return err
 	}
@@ -205,13 +205,13 @@ func (s *IAM) PutEniRole(ctx context.Context) error {
 func (s *IAM) PutRole(ctx context.Context) error {
 	var apiErr smithy.APIError
 
-	roleDocument, err := s.config.RoleDocument()
+	roleDocument, err := s.config.IAM().RoleDocument()
 	if err != nil {
 		return err
 	}
 
 	var tagSlice []types.Tag
-	for key, value := range s.config.Tags() {
+	for key, value := range s.config.Schema().Tags() {
 		tagSlice = append(tagSlice, types.Tag{
 			Key:   aws.String(key),
 			Value: aws.String(value),
@@ -219,12 +219,12 @@ func (s *IAM) PutRole(ctx context.Context) error {
 	}
 
 	create := &iam.CreateRoleInput{
-		RoleName:                 aws.String(s.config.ResourceName()),
+		RoleName:                 aws.String(s.config.Schema().Name()),
 		AssumeRolePolicyDocument: aws.String(roleDocument),
 	}
 
-	if s.config.BoundaryPolicyArn() != "" {
-		create.PermissionsBoundary = aws.String(s.config.BoundaryPolicyArn())
+	if s.config.IAM().BoundaryPolicyArn() != "" {
+		create.PermissionsBoundary = aws.String(s.config.IAM().BoundaryPolicyArn())
 	}
 
 	updatePolicy := &iam.UpdateAssumeRolePolicyInput{
@@ -233,15 +233,15 @@ func (s *IAM) PutRole(ctx context.Context) error {
 	}
 
 	tag := &iam.TagRoleInput{
-		RoleName: aws.String(s.config.ResourceName()),
+		RoleName: aws.String(s.config.Schema().Name()),
 		Tags:     tagSlice,
 	}
 
-	_, err = s.config.Iam.Client.CreateRole(ctx, create)
+	_, err = s.config.IAM().Client().CreateRole(ctx, create)
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
 		case "EntityAlreadyExists":
-			_, err = s.config.Iam.Client.UpdateAssumeRolePolicy(ctx, updatePolicy)
+			_, err = s.config.IAM().Client().UpdateAssumeRolePolicy(ctx, updatePolicy)
 			if err != nil {
 				return err
 			}
@@ -251,7 +251,7 @@ func (s *IAM) PutRole(ctx context.Context) error {
 		}
 	}
 
-	_, err = s.config.Iam.Client.TagRole(ctx, tag)
+	_, err = s.config.IAM().Client().TagRole(ctx, tag)
 	if err != nil {
 		return err
 	}
@@ -263,31 +263,31 @@ func (s *IAM) AttachRolePolicy(ctx context.Context) error {
 	var apiErr smithy.APIError
 
 	attach := &iam.AttachRolePolicyInput{
-		PolicyArn: aws.String(s.config.PolicyArn()),
-		RoleName:  aws.String(s.config.ResourceName()),
+		PolicyArn: aws.String(s.config.IAM().PolicyArn()),
+		RoleName:  aws.String(s.config.Schema().Name()),
 	}
 
-	_, err := s.config.Iam.Client.AttachRolePolicy(ctx, attach)
+	_, err := s.config.IAM().Client().AttachRolePolicy(ctx, attach)
 	if err != nil {
 		return err
 	}
 
-	if s.config.BoundaryPolicyArn() != "" {
+	if s.config.IAM().BoundaryPolicyArn() != "" {
 		boundary := &iam.PutRolePermissionsBoundaryInput{
-			RoleName:            aws.String(s.config.ResourceName()),
-			PermissionsBoundary: aws.String(s.config.BoundaryPolicyArn()),
+			RoleName:            aws.String(s.config.Schema().Name()),
+			PermissionsBoundary: aws.String(s.config.IAM().BoundaryPolicyArn()),
 		}
 
-		_, err := s.config.Iam.Client.PutRolePermissionsBoundary(ctx, boundary)
+		_, err := s.config.IAM().Client().PutRolePermissionsBoundary(ctx, boundary)
 		if err != nil {
 			return err
 		}
 	} else {
 		boundary := &iam.DeleteRolePermissionsBoundaryInput{
-			RoleName: aws.String(s.config.ResourceName()),
+			RoleName: aws.String(s.config.Schema().Name()),
 		}
 
-		_, err := s.config.Iam.Client.DeleteRolePermissionsBoundary(ctx, boundary)
+		_, err := s.config.IAM().Client().DeleteRolePermissionsBoundary(ctx, boundary)
 		if errors.As(err, &apiErr) {
 			switch apiErr.ErrorCode() {
 			case "NoSuchEntity":
@@ -307,15 +307,15 @@ func (s *IAM) DetachRolePolicy(ctx context.Context) error {
 	var apiErr smithy.APIError
 
 	detach := &iam.DetachRolePolicyInput{
-		PolicyArn: aws.String(s.config.PolicyArn()),
-		RoleName:  aws.String(s.config.ResourceName()),
+		PolicyArn: aws.String(s.config.IAM().PolicyArn()),
+		RoleName:  aws.String(s.config.Schema().Name()),
 	}
 
 	boundary := &iam.DeleteRolePermissionsBoundaryInput{
 		RoleName: detach.RoleName,
 	}
 
-	_, err := s.config.Iam.Client.DeleteRolePermissionsBoundary(ctx, boundary)
+	_, err := s.config.IAM().Client().DeleteRolePermissionsBoundary(ctx, boundary)
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
 		case "NoSuchEntity":
@@ -326,7 +326,7 @@ func (s *IAM) DetachRolePolicy(ctx context.Context) error {
 		}
 	}
 
-	_, err = s.config.Iam.Client.DetachRolePolicy(ctx, detach)
+	_, err = s.config.IAM().Client().DetachRolePolicy(ctx, detach)
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
 		case "NoSuchEntity":
@@ -344,10 +344,10 @@ func (s *IAM) DeleteRole(ctx context.Context) error {
 	var apiErr smithy.APIError
 
 	delete := &iam.DeleteRoleInput{
-		RoleName: aws.String(s.config.ResourceName()),
+		RoleName: aws.String(s.config.Schema().Name()),
 	}
 
-	_, err := s.config.Iam.Client.DeleteRole(ctx, delete)
+	_, err := s.config.IAM().Client().DeleteRole(ctx, delete)
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
 		case "NoSuchEntity":
@@ -364,14 +364,14 @@ func (s *IAM) DeletePolicy(ctx context.Context) error {
 	var apiErr smithy.APIError
 
 	delete := &iam.DeletePolicyInput{
-		PolicyArn: aws.String(s.config.PolicyArn()),
+		PolicyArn: aws.String(s.config.IAM().PolicyArn()),
 	}
 
-	if err := s.GCPolicyVersions(ctx, s.config.PolicyArn()); err != nil {
+	if err := s.GCPolicyVersions(ctx, s.config.IAM().PolicyArn()); err != nil {
 		return err
 	}
 
-	_, err := s.config.Iam.Client.DeletePolicy(ctx, delete)
+	_, err := s.config.IAM().Client().DeletePolicy(ctx, delete)
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
 		case "NoSuchEntity":
@@ -393,7 +393,7 @@ func (s *IAM) GCPolicyVersions(ctx context.Context, policyArn string) error {
 		PolicyArn: aws.String(policyArn),
 	}
 
-	policyVersions, err := s.config.Iam.Client.ListPolicyVersions(ctx, index)
+	policyVersions, err := s.config.IAM().Client().ListPolicyVersions(ctx, index)
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
 		case "NoSuchEntity":
@@ -410,7 +410,7 @@ func (s *IAM) GCPolicyVersions(ctx context.Context, policyArn string) error {
 				VersionId: version.VersionId,
 			}
 
-			if _, err = s.config.Iam.Client.DeletePolicyVersion(ctx, delete); err != nil {
+			if _, err = s.config.IAM().Client().DeletePolicyVersion(ctx, delete); err != nil {
 				if errors.As(err, &apiErr) {
 					switch apiErr.ErrorCode() {
 					case "NoSuchEntity":

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -21,7 +21,7 @@ func Init(ctx context.Context, c param.Aws) *State {
 
 func (s *State) List(ctx context.Context) ([]*param.StateMetadata, error) {
 	list := &lambda.ListFunctionsInput{}
-	functions, err := s.config.Lambda.Client.ListFunctions(ctx, list)
+	functions, err := s.config.Lambda().Client().ListFunctions(ctx, list)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add the ability to provide multiple `--route`/`--auth` pairs. Enabling this kind of business...

```bash
monad deploy \
--route "ANY /private/{proxy+}" --auth auth0 \
--route "ANY /public/{proxy+}" --auth none
```

Or if you are slightly psychotic...

```bash
monad deploy \
--route "ANY /ops/{proxy+}" --auth aws_iam \
--route "ANY /api/{proxy+}" --auth auth0 \
--route "ANY /public/{proxy+}" --auth none
``` 