### PR TITLE
Lazy load config

### DIFF
--- a/cmd/monad/main.go
+++ b/cmd/monad/main.go
@@ -50,7 +50,7 @@ func Steps(ctx context.Context) (*step.Steps, error) {
 		return nil, err
 	}
 
-	return step.Derive(config)
+	return step.Derive(ctx, config)
 }
 
 func Saga(ctx context.Context) (*saga.Saga, error) {
@@ -77,7 +77,12 @@ func Registry(ctx context.Context) (*registry.Client, error) {
 		return nil, err
 	}
 
-	return registry.Derive(config.Ecr()), nil
+	ecrConfig, err := config.Ecr(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return registry.Derive(ecrConfig), nil
 }
 
 func main() {

--- a/cmd/monad/main.go
+++ b/cmd/monad/main.go
@@ -4,16 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
+	"github.com/bkeane/monad/cmd/monad/pkg"
 	"github.com/bkeane/monad/pkg/basis"
 	"github.com/bkeane/monad/pkg/config"
 	"github.com/bkeane/monad/pkg/flag"
-	"github.com/bkeane/monad/pkg/registry"
-	"github.com/bkeane/monad/pkg/saga"
 	"github.com/bkeane/monad/pkg/scaffold"
-	"github.com/bkeane/monad/pkg/state"
-	"github.com/bkeane/monad/pkg/step"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -29,60 +25,6 @@ func init() {
 			zerolog.SetGlobalLevel(level)
 		}
 	}
-}
-
-func Basis(ctx context.Context) (*basis.Basis, error) {
-	return basis.Derive(ctx)
-}
-
-func Config(ctx context.Context) (*config.Config, error) {
-	basis, err := Basis(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return config.Derive(ctx, basis)
-}
-
-func Steps(ctx context.Context) (*step.Steps, error) {
-	config, err := Config(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return step.Derive(ctx, config)
-}
-
-func Saga(ctx context.Context) (*saga.Saga, error) {
-	steps, err := Steps(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return saga.Derive(ctx, steps), nil
-}
-
-func Scaffold(ctx context.Context) (*scaffold.Scaffold, error) {
-	basis, err := Basis(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return scaffold.Derive(basis), nil
-}
-
-func Registry(ctx context.Context) (*registry.Client, error) {
-	config, err := Config(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	ecrConfig, err := config.Ecr(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return registry.Derive(ecrConfig), nil
 }
 
 func main() {
@@ -108,7 +50,7 @@ func main() {
 						return fmt.Errorf("language is required")
 					}
 
-					scaffold, err := Scaffold(ctx)
+					scaffold, err := pkg.Scaffold(ctx)
 					if err != nil {
 						return err
 					}
@@ -122,7 +64,7 @@ func main() {
 				Flags:  flag.Flags[config.Config](),
 				Before: flag.Before[config.Config](),
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					saga, err := Saga(ctx)
+					saga, err := pkg.Saga(ctx)
 					if err != nil {
 						return err
 					}
@@ -134,7 +76,7 @@ func main() {
 				Name:  "destroy",
 				Usage: "destroy a monad",
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					saga, err := Saga(ctx)
+					saga, err := pkg.Saga(ctx)
 					if err != nil {
 						return err
 					}
@@ -146,7 +88,7 @@ func main() {
 				Name:  "list",
 				Usage: "list monads",
 				Action: func(ctx context.Context, c *cli.Command) error {
-					state, err := state.Init(ctx)
+					state, err := pkg.State(ctx)
 					if err != nil {
 						return err
 					}
@@ -169,7 +111,7 @@ func main() {
 						Name:  "login",
 						Usage: "login to ecr",
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							registry, err := Registry(ctx)
+							registry, err := pkg.Registry(ctx)
 							if err != nil {
 								return err
 							}
@@ -181,7 +123,7 @@ func main() {
 						Name:  "init",
 						Usage: "initialize monad repository",
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							registry, err := Registry(ctx)
+							registry, err := pkg.Registry(ctx)
 							if err != nil {
 								return err
 							}
@@ -193,7 +135,7 @@ func main() {
 						Name:  "destroy",
 						Usage: "destroy a monad repository",
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							registry, err := Registry(ctx)
+							registry, err := pkg.Registry(ctx)
 							if err != nil {
 								return err
 							}
@@ -205,7 +147,7 @@ func main() {
 						Name:  "untag",
 						Usage: "untag a monad image",
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							registry, err := Registry(ctx)
+							registry, err := pkg.Registry(ctx)
 							if err != nil {
 								return err
 							}
@@ -223,20 +165,17 @@ func main() {
 						Name:  "list",
 						Usage: "list available key/values",
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							basis, err := Basis(ctx)
+							basis, err := pkg.Basis(ctx)
 							if err != nil {
 								return err
 							}
 
-							vars := []string{"{{.Account.Id}}", "{{.Account.Region}}", "{{.Git.Repo}}", "{{.Git.Owner}}", "{{.Git.Branch}}", "{{.Git.Sha}}", "{{.Service.Name}}", "{{.Resource.Name}}", "{{.Resource.Path}}"}
-
-							for _, v := range vars {
-								val, err := basis.Render(v)
-								if err != nil {
-									return fmt.Errorf("failed to render %s: %w", v, err)
-								}
-								fmt.Printf("%-25s %s\n", v, strings.TrimSpace(val))
+							table, err := basis.Table()
+							if err != nil {
+								return err
 							}
+
+							fmt.Print(table)
 							return nil
 						},
 					},
@@ -249,7 +188,7 @@ func main() {
 								return fmt.Errorf("file required")
 							}
 
-							basis, err := Basis(ctx)
+							basis, err := pkg.Basis(ctx)
 							if err != nil {
 								return err
 							}

--- a/cmd/monad/pkg/pkg.go
+++ b/cmd/monad/pkg/pkg.go
@@ -1,0 +1,72 @@
+package pkg
+
+import (
+	"context"
+
+	"github.com/bkeane/monad/pkg/basis"
+	"github.com/bkeane/monad/pkg/config"
+	"github.com/bkeane/monad/pkg/registry"
+	"github.com/bkeane/monad/pkg/saga"
+	"github.com/bkeane/monad/pkg/scaffold"
+	"github.com/bkeane/monad/pkg/state"
+	"github.com/bkeane/monad/pkg/step"
+)
+
+func Basis(ctx context.Context) (*basis.Basis, error) {
+	return basis.Derive(ctx)
+}
+
+func Config(ctx context.Context) (*config.Config, error) {
+	basis, err := Basis(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return config.Derive(ctx, basis)
+}
+
+func Saga(ctx context.Context) (*saga.Saga, error) {
+	config, err := Config(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	steps, err := step.Derive(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return saga.Derive(ctx, steps), nil
+}
+
+func Scaffold(ctx context.Context) (*scaffold.Scaffold, error) {
+	basis, err := Basis(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return scaffold.Derive(basis), nil
+}
+
+func Registry(ctx context.Context) (*registry.Client, error) {
+	config, err := Config(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ecrConfig, err := config.Ecr(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return registry.Derive(ecrConfig), nil
+}
+
+func State(ctx context.Context) (*state.State, error) {
+	basis, err := Basis(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return state.Init(ctx, basis)
+}

--- a/pkg/basis/basis.go
+++ b/pkg/basis/basis.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -16,6 +17,7 @@ import (
 	"github.com/bkeane/monad/pkg/basis/service"
 	"github.com/rs/zerolog/log"
 
+	"github.com/charmbracelet/lipgloss/table"
 	env "github.com/caarlos0/env/v11"
 	v "github.com/go-ozzo/ozzo-validation/v4"
 )
@@ -193,6 +195,33 @@ func (b *Basis) Render(input string) (string, error) {
 	}
 
 	return buf.String(), nil
+}
+
+func (b *Basis) Table() (string, error) {
+	vars := []string{
+		"{{.Account.Id}}", 
+		"{{.Account.Region}}", 
+		"{{.Git.Repo}}", 
+		"{{.Git.Owner}}", 
+		"{{.Git.Branch}}", 
+		"{{.Git.Sha}}", 
+		"{{.Service.Name}}", 
+		"{{.Resource.Name}}", 
+		"{{.Resource.Path}}",
+	}
+
+	tbl := table.New()
+	tbl.Headers("Template", "Value")
+
+	for _, v := range vars {
+		val, err := b.Render(v)
+		if err != nil {
+			return "", fmt.Errorf("failed to render %s: %w", v, err)
+		}
+		tbl.Row(v, strings.TrimSpace(val))
+	}
+
+	return tbl.Render(), nil
 }
 
 //

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,14 +39,14 @@ type Basis interface {
 //
 
 type Config struct {
-	// Private fields for lazy loading
-	apigateway  *apigateway.Config
-	cloudwatch  *cloudwatch.Config
-	eventbridge *eventbridge.Config
-	iam         *iam.Config
-	lambda      *lambda.Config
-	ecr         *ecr.Config
-	vpc         *vpc.Config
+	// Fields for cached lazy loading and flag definition
+	ApiGatewayCfg  *apigateway.Config
+	CloudWatchCfg  *cloudwatch.Config
+	EventBridgeCfg *eventbridge.Config
+	IamCfg         *iam.Config
+	LambdaCfg      *lambda.Config
+	EcrCfg         *ecr.Config
+	VpcCfg         *vpc.Config
 
 	// Basis for lazy initialization
 	basis Basis
@@ -76,125 +76,125 @@ func Derive(ctx context.Context, basis Basis) (*Config, error) {
 func (c *Config) Lambda(ctx context.Context) (*lambda.Config, error) {
 	var err error
 
-	if c.lambda == nil {
-		c.lambda, err = lambda.Derive(ctx, c.basis)
+	if c.LambdaCfg == nil {
+		c.LambdaCfg, err = lambda.Derive(ctx, c.basis)
 		if err != nil {
 			return nil, err
 		}
 
-		err = c.lambda.Validate()
+		err = c.LambdaCfg.Validate()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return c.lambda, nil
+	return c.LambdaCfg, nil
 }
 
 func (c *Config) ApiGateway(ctx context.Context) (*apigateway.Config, error) {
 	var err error
 
-	if c.apigateway == nil {
-		c.apigateway, err = apigateway.Derive(ctx, c.basis)
+	if c.ApiGatewayCfg == nil {
+		c.ApiGatewayCfg, err = apigateway.Derive(ctx, c.basis)
 		if err != nil {
 			return nil, err
 		}
 
-		err = c.apigateway.Validate()
+		err = c.ApiGatewayCfg.Validate()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return c.apigateway, nil
+	return c.ApiGatewayCfg, nil
 }
 
 func (c *Config) EventBridge(ctx context.Context) (*eventbridge.Config, error) {
 	var err error
 
-	if c.eventbridge == nil {
-		c.eventbridge, err = eventbridge.Derive(ctx, c.basis)
+	if c.EventBridgeCfg == nil {
+		c.EventBridgeCfg, err = eventbridge.Derive(ctx, c.basis)
 		if err != nil {
 			return nil, err
 		}
 
-		err = c.eventbridge.Validate()
+		err = c.EventBridgeCfg.Validate()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return c.eventbridge, nil
+	return c.EventBridgeCfg, nil
 }
 
 func (c *Config) CloudWatch(ctx context.Context) (*cloudwatch.Config, error) {
 	var err error
 
-	if c.cloudwatch == nil {
-		c.cloudwatch, err = cloudwatch.Derive(ctx, c.basis)
+	if c.CloudWatchCfg == nil {
+		c.CloudWatchCfg, err = cloudwatch.Derive(ctx, c.basis)
 		if err != nil {
 			return nil, err
 		}
 
-		err = c.cloudwatch.Validate()
+		err = c.CloudWatchCfg.Validate()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return c.cloudwatch, nil
+	return c.CloudWatchCfg, nil
 }
 
 func (c *Config) Ecr(ctx context.Context) (*ecr.Config, error) {
 	var err error
 
-	if c.ecr == nil {
-		c.ecr, err = ecr.Derive(ctx, c.basis)
+	if c.EcrCfg == nil {
+		c.EcrCfg, err = ecr.Derive(ctx, c.basis)
 		if err != nil {
 			return nil, err
 		}
 
-		err = c.ecr.Validate()
+		err = c.EcrCfg.Validate()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return c.ecr, nil
+	return c.EcrCfg, nil
 }
 
 func (c *Config) Iam(ctx context.Context) (*iam.Config, error) {
 	var err error
 
-	if c.iam == nil {
-		c.iam, err = iam.Derive(ctx, c.basis)
+	if c.IamCfg == nil {
+		c.IamCfg, err = iam.Derive(ctx, c.basis)
 		if err != nil {
 			return nil, err
 		}
 
-		err = c.iam.Validate()
+		err = c.IamCfg.Validate()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return c.iam, nil
+	return c.IamCfg, nil
 }
 
 func (c *Config) Vpc(ctx context.Context) (*vpc.Config, error) {
 	var err error
 
-	if c.vpc == nil {
-		c.vpc, err = vpc.Derive(ctx, c.basis)
+	if c.VpcCfg == nil {
+		c.VpcCfg, err = vpc.Derive(ctx, c.basis)
 		if err != nil {
 			return nil, err
 		}
 
-		err = c.vpc.Validate()
+		err = c.VpcCfg.Validate()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return c.vpc, nil
+	return c.VpcCfg, nil
 }

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -19,8 +19,8 @@ type Basis interface {
 type Scaffold struct {
 	basis       Basis
 	WritePolicy bool `env:"MONAD_SCAFFOLD_POLICY"`
-	WriteRole   bool `env:"MONAD_SCAFFOLD_ROLE`
-	WriteEnv    bool `env:"MONAD_SCAFFOLD_ENV`
+	WriteRole   bool `env:"MONAD_SCAFFOLD_ROLE"`
+	WriteEnv    bool `env:"MONAD_SCAFFOLD_ENV"`
 }
 
 func Derive(basis Basis) *Scaffold {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -31,12 +31,7 @@ type State struct {
 	client *lambda.Client
 }
 
-func Init(ctx context.Context) (*State, error) {
-	basis, err := basis.Derive(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+func Init(ctx context.Context, basis *basis.Basis) (*State, error) {
 	return &State{
 		basis:  basis,
 		client: lambda.NewFromConfig(basis.AwsConfig()),


### PR DESCRIPTION
config spans a wide number of possible service calls. so access to the different configuration namespaces is now lazily interpreted, meaning if something uses config, but doesn't use ECR, the use of config wont actually necessitate a call to ECR. This is useful for scenarios where your permissions are divided up (ie in CI/CD)